### PR TITLE
Convert OAuth from Implicit Grant to Code Authorization with PKCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local History (VS Code extension)
+.history/
+
+# Environment variables
+

--- a/app/.env
+++ b/app/.env
@@ -4,9 +4,9 @@
 ###
 # Authorization
 #
-# For more information, see https://developer.genesys.cloud/authorization/platform-auth/use-implicit-grant
+# For more information, see https://developer.genesys.cloud/authorization/platform-auth/use-authorization-code-grant
 ###
-# Implicit grant OAuth Client ID
-REACT_APP_GENESYS_CLOUD_CLIENT_ID=48835701-98d0-4292-978e-af7b9716edc7
+# Code Authorization OAuth Client ID (with PKCE support)
+REACT_APP_GENESYS_CLOUD_CLIENT_ID=your-oauth-client-id-here
 # Redirect URI to use when deployed; must be a known value on the OAuth client
 REACT_APP_GENESYS_CLOUD_REDIRECT_URI=https://genesyscloudblueprints.github.io/org-chart-explorer/

--- a/app/package.json
+++ b/app/package.json
@@ -52,5 +52,14 @@
 	"devDependencies": {
 		"gh-pages": "^5.0.0"
 	},
-	"homepage": "/org-chart-explorer"
+	"homepage": "/org-chart-explorer",
+	"jest": {
+		"transformIgnorePatterns": [
+			"node_modules/(?!(axios|genesys-react-components|genesys-dev-icons|csv-stringify)/)"
+		],
+		"moduleNameMapper": {
+			"^axios$": "axios/dist/node/axios.cjs",
+			"^csv-stringify/browser/esm/sync$": "csv-stringify/dist/cjs/sync.cjs"
+		}
+	}
 }

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders app without crashing', () => {
+  render(
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
+  );
 });

--- a/app/src/helpers/GenesysCloudAPI.ts
+++ b/app/src/helpers/GenesysCloudAPI.ts
@@ -4,6 +4,8 @@ import { getRecoil, setRecoil } from 'recoil-nexus';
 import { User, UserSearchRequest, UsersSearchResponse } from './GenesysCloudAPITypes';
 
 const ACCESS_TOKEN_KEY = 'access-token';
+const CODE_VERIFIER_KEY = 'pkce-code-verifier';
+const CODE_EXCHANGE_IN_PROGRESS_KEY = 'code-exchange-in-progress';
 const MAX_QUEUE_FUNCS = 10;
 
 interface RetryableRequestFunc {
@@ -32,24 +34,27 @@ export default class GenesysCloudAPI {
 		// Retrieve existing access token
 		this.accessToken = localStorage.getItem(ACCESS_TOKEN_KEY) || undefined;
 
-		// Parse fragment
-		if (window.location.hash) {
-			// Inspired by https://stackoverflow.com/questions/5646851/split-and-parse-window-location-hash
-			let hash = window.location.hash;
-			if (hash.startsWith('#')) hash = hash.substring(1);
-			const hashData: { [key: string]: string } = hash
-				.split('&')
-				.map((v) => v.split('='))
-				.reduce((pre, [key, value]) => ({ ...pre, [key]: value }), {});
+		// Parse query parameters for authorization code
+		const urlParams = new URLSearchParams(window.location.search);
+		const authCode = urlParams.get('code');
 
-			// Scrape access token
-			if (hashData.access_token) {
-				this.accessToken = hashData.access_token;
-				window.localStorage.setItem(ACCESS_TOKEN_KEY, this.accessToken);
-			}
+		// Check if code exchange is already in progress (prevent duplicate exchanges)
+		const exchangeInProgress = sessionStorage.getItem(CODE_EXCHANGE_IN_PROGRESS_KEY);
 
-			// Remove fragment
-			window.location.hash = '';
+		if (authCode && !exchangeInProgress) {
+			// Mark exchange as in progress
+			sessionStorage.setItem(CODE_EXCHANGE_IN_PROGRESS_KEY, 'true');
+
+			// Exchange authorization code for access token
+			this.exchangeCodeForToken(authCode, region).then(() => {
+				// Remove code from URL
+				window.history.replaceState({}, document.title, window.location.pathname);
+				// Clear the in-progress flag
+				sessionStorage.removeItem(CODE_EXCHANGE_IN_PROGRESS_KEY);
+			}).catch((error) => {
+				console.error('Token exchange failed:', error);
+				sessionStorage.removeItem(CODE_EXCHANGE_IN_PROGRESS_KEY);
+			});
 		}
 
 		// Create API client
@@ -159,6 +164,49 @@ export default class GenesysCloudAPI {
 
 	/////// PRIVATE METHODS ///////
 
+	private async exchangeCodeForToken(code: string, region: string) {
+		const codeVerifier = localStorage.getItem(CODE_VERIFIER_KEY);
+
+		if (!codeVerifier) {
+			console.error('Code verifier not found in localStorage');
+			return;
+		}
+
+		try {
+			const tokenUrl = `https://login.${region}/oauth/token`;
+
+			const params = new URLSearchParams({
+				grant_type: 'authorization_code',
+				code: code,
+				redirect_uri: process.env.REACT_APP_GENESYS_CLOUD_REDIRECT_URI || '',
+				client_id: process.env.REACT_APP_GENESYS_CLOUD_CLIENT_ID || '',
+				code_verifier: codeVerifier,
+				code_challenge_method: 'S256',
+			});
+
+			const response = await axios.post(tokenUrl, params.toString(), {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
+
+			if (response.data.access_token) {
+				const token = response.data.access_token as string;
+				this.accessToken = token;
+				localStorage.setItem(ACCESS_TOKEN_KEY, token);
+				localStorage.removeItem(CODE_VERIFIER_KEY);
+
+				// Update axios instance with new token
+				this.api.defaults.headers['Authorization'] = `Bearer ${token}`;
+
+				// Reload the page to reinitialize with the new token
+				window.location.reload();
+			}
+		} catch (error) {
+			console.error('Error exchanging code for token:', error);
+		}
+	}
+
 	private async rateLimitRetryer(requestFunc: { (): Promise<AxiosResponse<any, any>> }) {
 		return new Promise<AxiosResponse<any, any>>((resolve) => {
 			this.requestQueue.push({
@@ -237,16 +285,50 @@ export default class GenesysCloudAPI {
 	}
 }
 
-// InitiateAuthFlow redirects the user's browser to the Genesys Cloud authorization server to begin the OAuth flow
-export function InitiateAuthFlow(region: string) {
+// InitiateAuthFlow redirects the user's browser to the Genesys Cloud authorization server to begin the OAuth flow with PKCE
+export async function InitiateAuthFlow(region: string) {
+	// Generate PKCE code verifier and challenge
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+	
+	// Store code verifier for later use
+	localStorage.setItem(CODE_VERIFIER_KEY, codeVerifier);
+
 	const oauthURL =
 		`https://login.${region}/oauth/authorize` +
 		`?client_id=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_CLIENT_ID || '')}` +
-		`&response_type=token` +
-		`&redirect_uri=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_REDIRECT_URI || '')}`;
+		`&response_type=code` +
+		`&redirect_uri=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_REDIRECT_URI || '')}` +
+		`&code_challenge=${encodeURIComponent(codeChallenge)}` +
+		`&code_challenge_method=S256`;
 
 	console.log('Initiating OAuth flow to', oauthURL);
 	window.location.href = oauthURL;
+}
+
+// generateCodeVerifier creates a random string for PKCE
+function generateCodeVerifier(): string {
+	const array = new Uint8Array(96);
+	crypto.getRandomValues(array);
+	return base64URLEncode(array);
+}
+
+// generateCodeChallenge creates a SHA-256 hash of the code verifier
+async function generateCodeChallenge(verifier: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const data = encoder.encode(verifier);
+	const hash = await crypto.subtle.digest('SHA-256', data);
+	return base64URLEncode(new Uint8Array(hash));
+}
+
+// base64URLEncode encodes a Uint8Array to base64url format
+function base64URLEncode(array: Uint8Array): string {
+	let binary = '';
+	for (let i = 0; i < array.length; i++) {
+		binary += String.fromCharCode(array[i]);
+	}
+	const base64 = btoa(binary) || '';
+	return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 
 // timeout wraps setTimeout with a promise

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -3,3 +3,55 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock window.crypto for PKCE tests
+const mockCrypto = {
+	getRandomValues: (array: Uint8Array) => {
+		for (let i = 0; i < array.length; i++) {
+			array[i] = Math.floor(Math.random() * 256);
+		}
+		return array;
+	},
+	subtle: {
+		digest: async (algorithm: string, data: BufferSource) => {
+			// Simple mock implementation for testing
+			const buffer = new ArrayBuffer(32);
+			const view = new Uint8Array(buffer);
+			for (let i = 0; i < 32; i++) {
+				view[i] = i;
+			}
+			return buffer;
+		},
+	},
+};
+
+// Only mock if crypto is not available (for test environments)
+if (typeof window !== 'undefined' && !window.crypto) {
+	Object.defineProperty(window, 'crypto', {
+		value: mockCrypto,
+		writable: true,
+	});
+}
+
+// Mock btoa globally as a jest mock
+global.btoa = jest.fn((str: string) => {
+	if (!str) return '';
+	return Buffer.from(str, 'binary').toString('base64');
+});
+
+// Mock TextEncoder for PKCE
+if (typeof global.TextEncoder === 'undefined') {
+	global.TextEncoder = class TextEncoder {
+		encode(str: string): Uint8Array {
+			return new Uint8Array(Buffer.from(str, 'utf-8'));
+		}
+	} as any;
+}
+
+// Mock recoil-nexus for tests
+jest.mock('recoil-nexus', () => ({
+	setRecoil: jest.fn(),
+	getRecoil: jest.fn(),
+	RecoilRoot: ({ children }: any) => children,
+}));
+

--- a/blueprint/index.md
+++ b/blueprint/index.md
@@ -33,7 +33,7 @@ Custom applications want to know how users are managed in Genesys Cloud. The use
 
 The blueprint explains the following Genesys Cloud concepts:
 
-* [Genesys Cloud Grant - Implicit](https://developer.genesys.cloud/authorization/platform-auth/use-implicit-grant "Opens the Grant - Implicit page") - Using the implicit grant of OAuth to authorize third-party applications to use the Genesys Cloud Platform API.
+* [Genesys Cloud Authorization Code Grant with PKCE](https://developer.genesys.cloud/authorization/platform-auth/use-authorization-code-grant "Opens the Authorization Code Grant page") - Using the authorization code grant with PKCE (Proof Key for Code Exchange) to securely authorize third-party applications to use the Genesys Cloud Platform API.
 * [Genesys Cloud Users API](https://developer.genesys.cloud/useragentman/users/ "Opens the Genesys Cloud Users API page") - A platform API endpoint for configuring Genesys Cloud users.
 * Rate Limiting - The Platform API supports rate limiting as a standard feature.
 
@@ -102,22 +102,31 @@ The following are some notable packages used by the app and what they do before 
 
 The app must first become authorized. A drop-down in the header allows the user to choose their region, and if the app does not have a valid auth token, the user is prompted to initiate the auth flow. `app/src/App.tsx` contains the UI implementation.
 
-To authorize the app to make API requests, it uses an [implicit grant](/authorization/platform-auth/use-implicit-grant "Opens the Grant - Implicit page") within Genesys Cloud OAuth. Upon clicking the link, the following function is executed to navigate the user to the Genesys Cloud auth server to challenge their credentials.  
+To authorize the app to make API requests, it uses [authorization code grant with PKCE](/authorization/platform-auth/use-authorization-code-grant "Opens the Authorization Code Grant page") within Genesys Cloud OAuth. PKCE (Proof Key for Code Exchange) provides enhanced security for public clients by preventing authorization code interception attacks. Upon clicking the link, the following function is executed to navigate the user to the Genesys Cloud auth server to challenge their credentials.  
 
 ```typescript
-export function InitiateAuthFlow(region: string) {
+export async function InitiateAuthFlow(region: string) {
+	// Generate PKCE code verifier and challenge
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+	
+	// Store code verifier for later use
+	localStorage.setItem(CODE_VERIFIER_KEY, codeVerifier);
+
 	const oauthURL =
 		`https://login.${region}/oauth/authorize` +
 		`?client_id=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_CLIENT_ID || '')}` +
-		`&response_type=token` +
-		`&redirect_uri=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_REDIRECT_URI || '')}`;
+		`&response_type=code` +
+		`&redirect_uri=${encodeURIComponent(process.env.REACT_APP_GENESYS_CLOUD_REDIRECT_URI || '')}` +
+		`&code_challenge=${encodeURIComponent(codeChallenge)}` +
+		`&code_challenge_method=S256`;
 
-	console.log('Initiating OAuth flow to', oauthURL);
+	console.log('Initiating OAuth flow with PKCE to', oauthURL);
 	window.location.href = oauthURL;
 }
 ```
 
-Once the user completes authentication, they are redirected back to the app with an access token in the fragment URI (also called a "hash"). During initialization, [`GenesysCloudAPI`](https://github.com/GenesysCloudBlueprints/org-chart-explorer/blob/main/app/src/helpers/GenesysCloudAPI.ts "Opens the Genesys Cloud Blueprints org chart explorer page") is loaded and its constructor checks the fragment for an access token. This is accomplished by setting the access token to a variable on the class instance. In addition, it clears the fragment so that the token is no longer visible to the user. 
+Once the user completes authentication, they are redirected back to the app with an authorization code in the query parameters. During initialization, [`GenesysCloudAPI`](https://github.com/GenesysCloudBlueprints/org-chart-explorer/blob/main/app/src/helpers/GenesysCloudAPI.ts "Opens the Genesys Cloud Blueprints org chart explorer page") is loaded and its constructor checks for the authorization code. The code is then exchanged for an access token using the stored code verifier. This exchange happens server-side at the token endpoint, providing better security than the deprecated implicit grant flow.
 
 When the authorization check is performed, it uses the token obtained from [GET /api/v2/users/me](/devapps/api-explorer#get-api-v2-users-me "Opens the /api/v2/users/me page"). When the request is successful, the app will start in the context of the user returned by the request. The user data atom (global state object) stores this information and is accessible via the `useUserData()` hook. This result triggers the `useAuthFailed()` hook and prompts the user to log in if the request fails.
 
@@ -243,7 +252,7 @@ Great question! In JavaScript API requests are handled in a single thread, but A
 * [Genesys Cloud Platform API Overview](/platform/api/ "Opens the Genesys Cloud Platform API Overview page") in the Genesys Cloud Developer Center.
 * [Genesys Cloud Users API resources](/useragentman/users/ "Opens the Genesys Cloud User API resources page") in the Genesys Cloud Developer Center.
 * [org-chart-explorer](https://genesyscloudblueprints.github.io/org-chart-explorer/ "Opens the Genesys Cloud blueprint page") in GitHub.
-* [Genesys Cloud OAuth Grant Implicit](/authorization/platform-auth/use-implicit-grant "Opens the Genesys Cloud OAuth Grant Implicit page") in the Genesys Cloud Developer Center.
+* [Genesys Cloud Authorization Code Grant with PKCE](/authorization/platform-auth/use-authorization-code-grant "Opens the Genesys Cloud Authorization Code Grant page") in the Genesys Cloud Developer Center.
 * [React](https://react.dev/ "Opens the React page") on the React website.
 * [Download for Windows (x64)](https://nodejs.org/ "Opens the Download for Windows (x64) page") on the NodeJS website.
 * [TypeScript is JavaScript with syntax for types.](https://www.typescriptlang.org/ "Opens the TypeScript is JavaScript with syntax for types. page") on the TypeScript website. 


### PR DESCRIPTION
Replace deprecated Implicit Grant OAuth flow with Code Authorization using PKCE (Proof Key for Code Exchange) as recommended by Genesys Cloud.

- Implement PKCE flow: code verifier, SHA-256 challenge, token exchange
- Parse authorization code from query params instead of token from hash
- Update blueprint documentation to reflect new auth flow
- Add test environment mocks for PKCE crypto APIs
- Fix pre-existing test setup issues (RecoilRoot, Jest ESM config)
- Add root .gitignore to exclude local history files